### PR TITLE
Added page for new pascal eolib.

### DIFF
--- a/docs/Game Libraries/eolib-pas.md
+++ b/docs/Game Libraries/eolib-pas.md
@@ -1,0 +1,22 @@
+---
+layout: page
+title: EOLib (Pas)
+permalink: /eolib-pas/
+parent: Libraries
+---
+
+# EOLib Pascal (Delphi/FPC)
+
+### About Library
+
+EOLib Pascal (Delphi/FPC) is a core Pascal library for writing Endless Online applications.
+
+Creator: [Cirras](https://github.com/Cirras)
+
+### Check it out on GitHub
+
+**Project Links:** [Main Branch](https://github.com/Cirras/eolib-pas/) | [Releases](https://github.com/Cirras/eolib-pas/releases/)
+
+### Read the docs
+
+**Documentation Links:** [Read Docs](https://cirras.github.io/eolib-pas/)


### PR DESCRIPTION
Updates:

- Added new page under /libraries/ for EOLib Pas by Cirras.